### PR TITLE
Migrate to AsyncMQTTClient

### DIFF
--- a/platformio.example.ini
+++ b/platformio.example.ini
@@ -21,7 +21,7 @@ flag_flash_size = -Wl,-Tesp8266.flash.1m128.ld
 flag_debug = -DDEBUG -Og -Wall
 lib_deps =
   ArduinoJson
-  PubSubClient
+  AsyncMqttClient
   xoseperez/my9291
   ESPAsyncTCP
   ESPAsyncWebServer

--- a/src/config.example.h
+++ b/src/config.example.h
@@ -59,6 +59,7 @@
 #define MQTT_RECONNECT_TIME 10000
 #define MQTT_QOS_LEVEL 0
 #define MQTT_RETAIN false
+#define MQTT_KEEPALIVE 30
 
 #define MQTT_PAYLOAD_ON "ON"
 #define MQTT_PAYLOAD_OFF "OFF"

--- a/src/main.h
+++ b/src/main.h
@@ -19,13 +19,13 @@
 #include "AiLight.hpp"
 #include "ArduinoOTA.h"
 #include <ArduinoJson.h>
+#include <AsyncMqttClient.h>
 #include <EEPROM.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266mDNS.h>
 #include <ESPAsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <Hash.h>
-#include <PubSubClient.h>
 #include <WiFiUdp.h>
 #include <vector>
 


### PR DESCRIPTION
Migrating to AsyncMQTT as this has some benefits over the PubSub client:

- Fully asynchronous
- Support sQOS0, QOS1 and QOS2 levels (publish and subscribe)
- Message length can be set on a per message basis 