### PR TITLE
[EXPLORATIONAL] Fix issues with deprecated discovery syntax in HomeAssistant 0.84

### DIFF
--- a/src/_web.ino
+++ b/src/_web.ino
@@ -104,6 +104,7 @@ void wsStart(uint8_t id) {
   settings[KEY_MQTT_LWT_TOPIC] = cfg.mqtt_lwt_topic;
   settings[KEY_MQTT_HA_USE_DISCOVERY] = cfg.mqtt_ha_use_discovery;
   settings[KEY_MQTT_HA_IS_DISCOVERED] = cfg.mqtt_ha_is_discovered;
+  settings[KEY_MQTT_HA_USE_LEGACY_DISCOVERY] = cfg.mqtt_ha_use_legacy_discovery;
 
   // Ensure HA MQTT Discovery Prefix has a proper value
   if (cfg.mqtt_ha_disc_prefix == NULL || cfg.mqtt_ha_disc_prefix[0] == 0xFF) {

--- a/src/light.ino
+++ b/src/light.ino
@@ -36,7 +36,12 @@ void deviceMQTTCallback(uint8_t type, const char *topic, const char *payload) {
       JsonObject &md_root = mqttJsonBuffer.createObject();
 
       md_root["name"] = cfg.hostname;
-      md_root["platform"] = "mqtt_json";
+      if (cfg.mqtt_ha_use_legacy_discovery) {
+        md_root["platform"] = "mqtt_json";
+      } else {
+        md_root["platform"] = "mqtt";
+        md_root["schema"] = "json";
+      }
       md_root["state_topic"] = cfg.mqtt_state_topic;
       md_root["command_topic"] = cfg.mqtt_command_topic;
       md_root["rgb"] = true;

--- a/src/main.h
+++ b/src/main.h
@@ -33,6 +33,10 @@
 #define MQTT_HOMEASSISTANT_DISCOVERY_PREFIX "homeassistant"
 #endif
 
+#ifndef MQTT_HOMEASSISTANT_USE_LEGACY_DISCOVERY
+#define MQTT_HOMEASSISTANT_USE_LEGACY_DISCOVERY false
+#endif
+
 #ifndef REST_API_ENABLED
 #define REST_API_ENABLED false
 #endif
@@ -95,6 +99,7 @@ static const int BUFFER_SIZE = JSON_OBJECT_SIZE(10);
 #define KEY_MQTT_HA_USE_DISCOVERY "switch_ha_discovery"
 #define KEY_MQTT_HA_IS_DISCOVERED "mqtt_ha_is_discovered"
 #define KEY_MQTT_HA_DISCOVERY_PREFIX "mqtt_ha_discovery_prefix"
+#define KEY_MQTT_HA_USE_LEGACY_DISCOVERY "mqtt_ha_use_legacy_discovery"
 #define KEY_REST_API_ENABLED "switch_rest_api"
 #define KEY_REST_API_KEY "api_key"
 #define KEY_POWERUP_MODE "powerup_mode"
@@ -150,6 +155,7 @@ struct config_t {
   bool mqtt_ha_use_discovery; // Home Assistant MQTT discovery enabled or not
   bool mqtt_ha_is_discovered; // Has this device already been discovered or not
   char mqtt_ha_disc_prefix[32]; // MQTT Discovery prefix for Home Assistant
+  bool mqtt_ha_use_legacy_discovery; // For HA <= 0.84, use "platform: mqtt_json" for discovery
   bool api;                     // REST API enabled or not
   char api_key[32];             // API Key
   uint8_t powerup_mode;         // Power Up Mode

--- a/src/main.ino
+++ b/src/main.ino
@@ -72,6 +72,7 @@ void loadFactoryDefaults() {
   cfg.mqtt_ha_use_discovery = MQTT_HOMEASSISTANT_DISCOVERY_ENABLED;
   cfg.mqtt_ha_is_discovered = false;
   os_strcpy(cfg.mqtt_ha_disc_prefix, MQTT_HOMEASSISTANT_DISCOVERY_PREFIX);
+  cfg.mqtt_ha_use_legacy_discovery = MQTT_HOMEASSISTANT_USE_LEGACY_DISCOVERY;
 
   os_strcpy(cfg.wifi_ssid, WIFI_SSID);
   os_strcpy(cfg.wifi_psk, WIFI_PSK);


### PR DESCRIPTION
This is an explorational PR that attempts to resolve Issue #51 in such a way that won't break lights for users of older HomeAssistant versions (< 0.84).

## ISSUE
Home Assistant 0.84 removed the "mqtt_json" platform type, replacing it with a combination of "platform: mqtt" with "schema: json". 

This breaks AiLight auto-discovery for users of HA >= 0.84 since current AiLight firmware only sends the now-legacy "mqtt_json" as a platform.

The resolution is simple, but could break lights for AiLights users running older versions of HA./

## PROPOSED SOLUTION

Add a variable in config.h that allows user to override the "new way" for HA discovery:

```
#define MQTT_HOMEASSISTANT_DISCOVERY_ENABLED false
#define MQTT_HOMEASSISTANT_DISCOVERY_PREFIX "homeassistant"

#define MQTT_HOMEASSISTANT_USE_LEGACY_DISCOVERY false
```