### PR TITLE
Add build_dir config property to support PlatformIO 4.0

### DIFF
--- a/platformio.example.ini
+++ b/platformio.example.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = dev
+build_dir = .pioenvs
 
 [common]
 platform = espressif8266@1.5.0


### PR DESCRIPTION
AiLight won't compile with PlatformIO 4.0. This is due to a breaking change in PlatformIO 4, but is considered "not a bug" and "wontfix": https://github.com/arendst/Sonoff-Tasmota/issues/6073#issuecomment-511109803

This PR duplicates the fix that Tasmota put into their platformio.ino default config -- adding the "build_dir" property and setting it to the old ".pioenvs".

This appears to work for me locally, but should be duplicated before merging permanently.