### PR TITLE
MQTT Stay alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 
 ### Added
-- my92XX Support. This allows for support of lightbulbs with the my9231 LED driver such as the LOHAS brand bulbs. [\#50](https://github.com/stelgenhof/AiLight/pull/50) ([Nick Wolff] (https://github.com/darkfiberiru))
+- my92XX Support. This allows for support of light bulbs with the my9231 LED driver such as the LOHAS brand bulbs
+. [\#50](https://github.com/stelgenhof/AiLight/pull/50) ([Nick Wolff] (https://github.com/darkfiberiru))
 
 ### Changed
 - The example PlatformIO configuration has been changed due to the release of PlatformIO v4.0. If you use PlatformIO make sure the configuration entry 'env_default' is renamed to 'default_envs' in your platformio.ini file!
 - Updated third-party dependencies.
 
 ### Fixed
+- Connection to the MQTT broker was assumed to be always present and in case of a disconnect, a retry would be
+ triggered. However in the case of the MQTT broker becoming unavailable, there was no possibility to get the
+  connection back except for restarting the device. This has been resolved by checking at regular intervals if the
+   connection is still there. [\#56](https://github.com/stelgenhof/AiLight/issues/56), [\#66](https://github.com
+   /stelgenhof/AiLight/issues/66).
 - Building with VSCode + PlatformIO 4.0 extension gives error: "`.text' will not fit in region `iram1_0_seg'". [\#59](https://github.com/stelgenhof/AiLight/pull/59) ([Donnie] (https://github.com/donkawechico))
 - Corrected duplicate 'platform' JSON definition (to 'schema') for the MQTT discovery message. [\#55](https://github.com/stelgenhof/AiLight/pull/55) ([Ole-Kenneth] (https://github.com/olekenneth))
 - Added link type (MIME type) for the HTML stylesheet to avoid potential misinterpretations.

--- a/src/_mqtt.ino
+++ b/src/_mqtt.ino
@@ -86,7 +86,6 @@ void mqttRegister(void (*callback)(uint8_t, const char *, const char *)) {
 void onMQTTConnect(bool sessionPresent) {
   DEBUGLOG("[MQTT] Connected\n");
 
-  _mqtt_last_connection = millis();
   _mqtt_connecting = false;
 
   // Notify subscribers (connected)
@@ -102,7 +101,6 @@ void onMQTTConnect(bool sessionPresent) {
 void onMQTTDisconnect(AsyncMqttClientDisconnectReason reason) {
   DEBUGLOG("[MQTT] Disconnected. Reason: %d\n", reason);
 
-  _mqtt_last_connection = millis();
   _mqtt_connecting = false;
 
   // Notify subscribers (disconnected)

--- a/src/_mqtt.ino
+++ b/src/_mqtt.ino
@@ -21,7 +21,7 @@
  */
 void mqttPublish(const char *topic, const char *message) {
   // Don't do anything if we are not connected to the MQTT broker
-  if (!mqtt.connected()) {
+  if (!mqtt.connected() || _mqtt_connecting) {
     return;
   }
 
@@ -40,7 +40,7 @@ void mqttPublish(const char *topic, const char *message) {
  */
 void mqttSubscribe(const char *topic, uint8_t qos = MQTT_QOS_LEVEL) {
   // Don't do anything if we are not connected to the MQTT broker
-  if (!mqtt.connected()) {
+  if (!mqtt.connected() || _mqtt_connecting) {
     return;
   }
 
@@ -58,7 +58,7 @@ void mqttSubscribe(const char *topic, uint8_t qos = MQTT_QOS_LEVEL) {
  */
 void mqttUnsubscribe(const char *topic) {
   // Don't do anything if we are not connected to the MQTT broker
-  if (!mqtt.connected()) {
+  if (!mqtt.connected() || _mqtt_connecting) {
     return;
   }
 
@@ -143,12 +143,11 @@ void mqttConnect() {
 
   // Do not make a connection if already connected or trying to
   if (mqtt.connected() || _mqtt_connecting) {
-    DEBUGLOG("[MQTT] Already connected or trying to connect.\n");
     return;
   }
 
   if (!os_strlen(cfg.mqtt_server) > 0) {
-    DEBUGLOG("[MQTT] MQTT Server not configured. Skipping MQTT.\n");
+    DEBUGLOG("[MQTT] MQTT Broker not configured.\n");
     return;
   }
 

--- a/src/light.ino
+++ b/src/light.ino
@@ -69,10 +69,6 @@ void deviceMQTTCallback(uint8_t type, const char *topic, const char *payload) {
   // Handling the event of disconnecting from the MQTT broker
   if (type == MQTT_EVENT_DISCONNECT) {
     mqttUnsubscribe(cfg.mqtt_command_topic);
-
-    //    if (WiFi.isConnected()) {
-    //      mqttReconnectTimer.attach(MQTT_RECONNECT_TIME, mqttConnect);
-    //    }
   }
 
   // Handling the event a message is received from the MQTT broker

--- a/src/light.ino
+++ b/src/light.ino
@@ -70,9 +70,9 @@ void deviceMQTTCallback(uint8_t type, const char *topic, const char *payload) {
   if (type == MQTT_EVENT_DISCONNECT) {
     mqttUnsubscribe(cfg.mqtt_command_topic);
 
-    if (WiFi.isConnected()) {
-      mqttReconnectTimer.once(MQTT_RECONNECT_TIME, mqttConnect);
-    }
+    //    if (WiFi.isConnected()) {
+    //      mqttReconnectTimer.attach(MQTT_RECONNECT_TIME, mqttConnect);
+    //    }
   }
 
   // Handling the event a message is received from the MQTT broker
@@ -91,7 +91,7 @@ void deviceMQTTCallback(uint8_t type, const char *topic, const char *payload) {
         return;
       }
 
-      // Store light parameters for persistance
+      // Store light parameters for persistence
       cfg.is_on = AiLight->getState();
       cfg.brightness = AiLight->getBrightness();
       cfg.color_temp = AiLight->getColorTemperature();
@@ -207,8 +207,8 @@ bool processJson(char *message) {
       stepCount = 0;
     } else {
       AiLight->setColor(root[KEY_COLOR][KEY_COLOR_R],
-                       root[KEY_COLOR][KEY_COLOR_G],
-                       root[KEY_COLOR][KEY_COLOR_B]);
+                        root[KEY_COLOR][KEY_COLOR_G],
+                        root[KEY_COLOR][KEY_COLOR_B]);
     }
   }
 
@@ -373,7 +373,8 @@ void loopLight() {
       flash = false;
 
       AiLight->setState(currentState);
-      AiLight->setColor(currentColor.red, currentColor.green, currentColor.blue);
+      AiLight->setColor(currentColor.red, currentColor.green,
+                        currentColor.blue);
       AiLight->setBrightness(currentBrightness);
 
       sendState(); // Notify subscribers again about current state
@@ -394,24 +395,24 @@ void loopLight() {
         // Transition/fade RGB LEDS (if level is different from current)
         if (stepR != 0 || stepG != 0 || stepB != 0) {
           AiLight->setColor(calculateLevel(stepR, AiLight->getColor().red,
-                                          stepCount, transColor.red),
-                           calculateLevel(stepG, AiLight->getColor().green,
-                                          stepCount, transColor.green),
-                           calculateLevel(stepB, AiLight->getColor().blue,
-                                          stepCount, transColor.blue));
+                                           stepCount, transColor.red),
+                            calculateLevel(stepG, AiLight->getColor().green,
+                                           stepCount, transColor.green),
+                            calculateLevel(stepB, AiLight->getColor().blue,
+                                           stepCount, transColor.blue));
         }
 
         // Transition/fade white LEDS (if level is different from current)
         if (stepW != 0) {
           AiLight->setWhite(calculateLevel(stepW, AiLight->getColor().white,
-                                          stepCount, transColor.white));
+                                           stepCount, transColor.white));
         }
 
         // Transition/fade brightness (if level is different from current)
         if (stepBrightness != 0) {
           AiLight->setBrightness(calculateLevel(stepBrightness,
-                                               AiLight->getBrightness(),
-                                               stepCount, transBrightness));
+                                                AiLight->getBrightness(),
+                                                stepCount, transBrightness));
         }
 
         stepCount++;

--- a/src/main.h
+++ b/src/main.h
@@ -162,15 +162,17 @@ struct config_t {
   char mqtt_password[64];     // Password used for connecting to the MQTT Broker
   char mqtt_state_topic[128]; // MQTT Topic for publishing the state
   char mqtt_command_topic[128]; // MQTT Topic for receiving commands
-  char mqtt_lwt_topic[128]; // MQTT Topic for publising Last Will and Testament
-  bool gamma;               // Gamma Correction enabled or not
+  char mqtt_lwt_topic[128];     // MQTT Topic for publishing Last Will and
+  // Testament
+  bool gamma;                 // Gamma Correction enabled or not
   bool mqtt_ha_use_discovery; // Home Assistant MQTT discovery enabled or not
-  bool mqtt_ha_is_discovered; // Has this device already been discovered or not
+  bool mqtt_ha_is_discovered; // Has this device already been discovered or
+  // not
   char mqtt_ha_disc_prefix[32]; // MQTT Discovery prefix for Home Assistant
   bool api;                     // REST API enabled or not
   char api_key[32];             // API Key
   uint8_t powerup_mode;         // Power Up Mode
-  my92xx_model_t chip_type;          // Device Type
+  my92xx_model_t chip_type;     // Device Type
   unsigned char chip_count;
 } cfg;
 
@@ -197,6 +199,10 @@ int stepR, stepG, stepB, stepW, stepBrightness = 0;
 uint16_t stepCount = 0;
 Color transColor;
 uint8_t transBrightness = 0;
+
+// Globals for MQTT
+uint32_t _mqtt_last_connection = 0;
+bool _mqtt_connecting = false;
 
 #ifdef DEBUG
 #define SerialPrint(format, ...)                                               \

--- a/src/main.h
+++ b/src/main.h
@@ -201,7 +201,6 @@ Color transColor;
 uint8_t transBrightness = 0;
 
 // Globals for MQTT
-uint32_t _mqtt_last_connection = 0;
 bool _mqtt_connecting = false;
 
 #ifdef DEBUG

--- a/src/main.ino
+++ b/src/main.ino
@@ -35,8 +35,7 @@ const char *getDeviceID() {
  *
  * @return the (formatted) version of the ESP Core framework
  */
-String getESPCoreVersion()
-{
+String getESPCoreVersion() {
   String version = ESP.getCoreVersion();
 
   version.replace("_", ".");
@@ -126,8 +125,8 @@ void setup() {
 #endif
   AiLight = new AiLightClass(cfg.chip_type, cfg.chip_count);
   setupLight();
-  setupMQTT();
   setupWiFi();
+  setupMQTT();
   setupOTA();
   setupWeb();
 


### PR DESCRIPTION
Connection to the MQTT broker was assumed to be always present and in case of a disconnect, a retry would be triggered. However in the case of the MQTT broker becoming unavailable, there was no possibility to get the connection back except for restarting the device. This has been resolved in this PR by checking at regular intervals if the connection is still alive. 