### PR TITLE
Add support for openHAB colorwheel

### DIFF
--- a/src/config.example.h
+++ b/src/config.example.h
@@ -103,3 +103,12 @@
  * These will be used as the factory defaults of your device.
  */
 #define REST_API_ENABLED false
+
+/**
+ * OpenHAB support
+ * ---------------------------
+ * To enable support for openHAB uncomment MQTT_OPENHAB_SUPPORT
+ * To change the used JSON key modify KEY_COLOR_ARRAY (default: "color_array") 
+ */
+//#define MQTT_OPENHAB_SUPPORT
+//#define KEY_COLOR_ARRAY "color_array"

--- a/src/light.ino
+++ b/src/light.ino
@@ -208,6 +208,7 @@ bool processJson(char *message) {
     }
   }
 
+#ifdef MQTT_OPENHAB_SUPPORT
   if (root.containsKey(KEY_COLOR_ARRAY)) {
 
     // In transition/fade
@@ -232,6 +233,7 @@ bool processJson(char *message) {
                         root[KEY_COLOR_ARRAY][2]);
     }
   }
+#endif
 
   if (root.containsKey(KEY_WHITE)) {
     // In transition/fade
@@ -334,10 +336,12 @@ void createStateJSON(JsonObject &object) {
   color[KEY_COLOR_G] = AiLight->getColor().green;
   color[KEY_COLOR_B] = AiLight->getColor().blue;
 
+#ifdef MQTT_OPENHAB_SUPPORT
   JsonArray &color_array = object.createNestedArray(KEY_COLOR_ARRAY);
   color_array.add(AiLight->getColor().red);
   color_array.add(AiLight->getColor().green);
   color_array.add(AiLight->getColor().blue);
+#endif
 
   object[KEY_GAMMA_CORRECTION] = AiLight->hasGammaCorrection();
 }

--- a/src/light.ino
+++ b/src/light.ino
@@ -208,6 +208,31 @@ bool processJson(char *message) {
     }
   }
 
+  if (root.containsKey(KEY_COLOR_ARRAY)) {
+
+    // In transition/fade
+    if (transitionTime > 0) {
+      transColor.red = root[KEY_COLOR_ARRAY][0];
+      transColor.green = root[KEY_COLOR_ARRAY][1];
+      transColor.blue = root[KEY_COLOR_ARRAY][2];
+
+      // If light is off, start fading from Zero
+      if (!AiLight->getState()) {
+        AiLight->setColor(0, 0, 0);
+      }
+
+      stepR = calculateStep(AiLight->getColor().red, transColor.red);
+      stepG = calculateStep(AiLight->getColor().green, transColor.green);
+      stepB = calculateStep(AiLight->getColor().blue, transColor.blue);
+
+      stepCount = 0;
+    } else {
+      AiLight->setColor(root[KEY_COLOR_ARRAY][0],
+                        root[KEY_COLOR_ARRAY][1],
+                        root[KEY_COLOR_ARRAY][2]);
+    }
+  }
+
   if (root.containsKey(KEY_WHITE)) {
     // In transition/fade
     if (transitionTime > 0) {
@@ -308,6 +333,11 @@ void createStateJSON(JsonObject &object) {
   color[KEY_COLOR_R] = AiLight->getColor().red;
   color[KEY_COLOR_G] = AiLight->getColor().green;
   color[KEY_COLOR_B] = AiLight->getColor().blue;
+
+  JsonArray &color_array = object.createNestedArray(KEY_COLOR_ARRAY);
+  color_array.add(AiLight->getColor().red);
+  color_array.add(AiLight->getColor().green);
+  color_array.add(AiLight->getColor().blue);
 
   object[KEY_GAMMA_CORRECTION] = AiLight->hasGammaCorrection();
 }

--- a/src/main.h
+++ b/src/main.h
@@ -36,6 +36,10 @@
 #define MQTT_HOMEASSISTANT_DISCOVERY_PRE_0_84 false
 #endif
 
+#ifndef KEY_COLOR_ARRAY
+#define KEY_COLOR_ARRAY "color_array"
+#endif
+
 #ifndef REST_API_ENABLED
 #define REST_API_ENABLED false
 #endif
@@ -70,7 +74,11 @@ extern "C" {
 
 #define EEPROM_START_ADDRESS 0
 #define INIT_HASH 0x5F
+#ifndef MQTT_OPENHAB_ENABLED
+static const int BUFFER_SIZE = JSON_OBJECT_SIZE(10);
+#else
 static const int BUFFER_SIZE = JSON_OBJECT_SIZE(13);
+#endif
 
 // Key names as used internally and in the WebUI
 #define KEY_SETTINGS "s"
@@ -82,7 +90,6 @@ static const int BUFFER_SIZE = JSON_OBJECT_SIZE(13);
 #define KEY_COLORTEMP "color_temp"
 #define KEY_FLASH "flash"
 #define KEY_COLOR "color"
-#define KEY_COLOR_ARRAY "color_array"
 #define KEY_COLOR_R "r"
 #define KEY_COLOR_G "g"
 #define KEY_COLOR_B "b"

--- a/src/main.h
+++ b/src/main.h
@@ -70,7 +70,7 @@ extern "C" {
 
 #define EEPROM_START_ADDRESS 0
 #define INIT_HASH 0x5F
-static const int BUFFER_SIZE = JSON_OBJECT_SIZE(10);
+static const int BUFFER_SIZE = JSON_OBJECT_SIZE(13);
 
 // Key names as used internally and in the WebUI
 #define KEY_SETTINGS "s"
@@ -82,6 +82,7 @@ static const int BUFFER_SIZE = JSON_OBJECT_SIZE(10);
 #define KEY_COLORTEMP "color_temp"
 #define KEY_FLASH "flash"
 #define KEY_COLOR "color"
+#define KEY_COLOR_ARRAY "color_array"
 #define KEY_COLOR_R "r"
 #define KEY_COLOR_G "g"
 #define KEY_COLOR_B "b"


### PR DESCRIPTION
OpenHAB does send the colors in a format like:
{"color_array":[250,12,16]} for (almost) red
{"color_array":[10,250,10]} for (almost) green
{"color_array":[17,29,250]} for (almost) blue

Added key color_array to src/main.h
Added parsing of color_array in processJson() to src/light.ino
This was only copied and might be not really nice...
Added array state to JSON object created in createStateJSON() in src/light.ino
This might also be not too elegant...
Changed JSON_OBJECT_SIZE to 13 to make enough space for the replied state message in src/main.h